### PR TITLE
Set DOCKER_HOST to use TCP to connect to daemon

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -96,6 +96,8 @@ CMD_EXIT_CODE=$?
 echo; echo
 echo "🏁 Exit code: $CMD_EXIT_CODE"
 
+rm outer_env_vars.env
+
 mkdir -p $IMAGE_CACHE_DIR
 docker image prune -f
 echo "💾 Exporting docker images to cache ($IMAGE_CACHE_DIR)"

--- a/command.sh
+++ b/command.sh
@@ -17,7 +17,12 @@ export PLUGIN_CMD="sh -c '${PLUGIN_CMD}'"
 echo "📦 Starting dind-drone-plugin"
 
 echo "🐳 Starting docker-in-docker daemon"
-/usr/local/bin/dockerd-entrypoint.sh dockerd --data-root /drone/docker -s ${PLUGIN_STORAGE_DRIVER:-vfs} --log-level error &
+/usr/local/bin/dockerd-entrypoint.sh dockerd \
+  --data-root /drone/docker \
+  -s ${PLUGIN_STORAGE_DRIVER:-vfs} \
+  --log-level error \
+  -H tcp://0.0.0.0:2375 \
+  -H unix:///var/run/docker.sock &
 
 for i in $(seq 1 30); do
   echo "⏳ Pinging docker daemon ($i/30)"
@@ -60,6 +65,15 @@ docker pull ${PLUGIN_BUILD_IMAGE} 2>&1 | sed 's/^/   /g'
 for k in $(compgen -e); do
   echo $k=${!k} >> ${PWD}/outer_env_vars.env
 done
+
+# Determine IP address at which dockerd and spawned containers can be reached
+DOCKER_IP=$(ip route | awk '/docker0/ { print $7 }')
+echo "DOCKER_HOST=tcp://${DOCKER_IP}:2375" >> ${PWD}/outer_env_vars.env
+echo "ℹ️  Docker daemon will be available in the build container:"
+echo "     at /var/run/docker.sock"
+echo "     at tcp://${DOCKER_IP}:2375 (no TLS)"
+echo "ℹ️  DOCKER_HOST will be set to tcp://${DOCKER_IP}:2375"
+echo "ℹ️  Containers spawned by the build container will be accessible at ${DOCKER_IP} (do not hardcode this value)"
 
 echo -e "\n\n"
 MSG="🚀 About to run command: ${PLUGIN_CMD} on image ${PLUGIN_BUILD_IMAGE} inside Docker-in-Docker"


### PR DESCRIPTION
The combined DinD/sidecar networking model breaks non-Testcontainers things which rely on the assumption that 'use of unix socket' == 'networking on localhost'

This change introduces a local TCP socket for the docker daemon, with `DOCKER_HOST` being set to point to it.

This changes helps support the DinD side of https://github.com/revolut-engineering/jooq-plugin/issues/3

In summary:

Previous behaviour: 
* `DOCKER_HOST` is not set, so Testcontainers and other docker clients use a unix socket to talk to the DinD daemon
* Testcontainers automatically detects that it's running in DinD, so uses the correct gateway IP address instead of localhost
* Other docker clients with less environment inference try to use localhost to talk to other containers, even though this is incorrect as they are actually 'siblings'

New behaviour: 
* The DinD docker daemon is now launched listening on both a unix socket and TCP
* This plugin determines the correct gateway IP address and sets this in `DOCKER_HOST` (i.e. like `tcp://$GATEWAY_IP:2375`)
* Testcontainers continues to be happy, and uses TCP to connect to the daemon (and for generated container IP addresses)
* Other docker clients can pick up the gateway IP from the `DOCKER_HOST` environment variable, and treat it as a remote docker daemon