### PR TITLE
don't overwrite all environment variables

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -52,7 +52,15 @@ docker pull ${PLUGIN_BUILD_IMAGE} 2>&1 | sed 's/^/   /g'
 
 # Ensure that secrets (passed through as env vars) are available. Iterate and purposefully omit newlines.
 for k in $(compgen -e); do
-  echo $k=${!k} >> ${PWD}/outer_env_vars.env
+  touch ${PWD}/outer_env_vars.env
+  case "$k" in
+      # avoid overwriting container's variables
+      DIND_COMMIT|DOCKER_CHANNEL|DOCKER_TLS_CERTDIR|DOCKER_VERSION|HOME|HOSTNAME|PATH|PWD|SHLVL)
+      ;;
+    *)
+      echo $k=${!k} >> ${PWD}/outer_env_vars.env
+      ;;
+  esac
 done
 
 # Determine IP address at which dockerd and spawned containers can be reached

--- a/command.sh
+++ b/command.sh
@@ -54,11 +54,10 @@ docker pull ${PLUGIN_BUILD_IMAGE} 2>&1 | sed 's/^/   /g'
 for k in $(compgen -e); do
   touch ${PWD}/outer_env_vars.env
   case "$k" in
-      # avoid overwriting container's variables
-      
-# Note that the env vars to blacklist may be found using
-#   `docker run -it --entrypoint env quay.io/testcontainers/dind-drone-plugin`
-   DIND_COMMIT|DOCKER_CHANNEL|DOCKER_TLS_CERTDIR|DOCKER_VERSION|HOME|HOSTNAME|PATH|PWD|SHLVL)
+    # avoid overwriting container's variables
+    # Note that the env vars to blacklist may be found using
+    #   `docker run -it --entrypoint env quay.io/testcontainers/dind-drone-plugin`
+    DIND_COMMIT|DOCKER_CHANNEL|DOCKER_TLS_CERTDIR|DOCKER_VERSION|HOME|HOSTNAME|PATH|PWD|SHLVL)
       ;;
     *)
       echo $k=${!k} >> ${PWD}/outer_env_vars.env

--- a/command.sh
+++ b/command.sh
@@ -55,7 +55,10 @@ for k in $(compgen -e); do
   touch ${PWD}/outer_env_vars.env
   case "$k" in
       # avoid overwriting container's variables
-      DIND_COMMIT|DOCKER_CHANNEL|DOCKER_TLS_CERTDIR|DOCKER_VERSION|HOME|HOSTNAME|PATH|PWD|SHLVL)
+      
+# Note that the env vars to blacklist may be found using
+#   `docker run -it --entrypoint env quay.io/testcontainers/dind-drone-plugin`
+   DIND_COMMIT|DOCKER_CHANNEL|DOCKER_TLS_CERTDIR|DOCKER_VERSION|HOME|HOSTNAME|PATH|PWD|SHLVL)
       ;;
     *)
       echo $k=${!k} >> ${PWD}/outer_env_vars.env


### PR DESCRIPTION
👋 hey, thanks for the plugin! We've found it very useful.

At the moment it has the somewhat tricky behavior of overriding the inner container's PATH and SHELL. We found this breaks openjdk images, for example. This code just blacklists environment variables which are already set by the image.

One downside of this would be if you foresee people intentionally overwriting the PATH in their drone secrets. If you think that's a problem we could try parsing to see if the variables changed.