### PR TITLE
Update to `docker:20.10.16-dind` to avoid cgroups v2 issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.5-dind
+FROM docker:20.10.16-dind
 
 RUN apk add --no-cache bash jq
 


### PR DESCRIPTION
Hello! We came across an issue today with a Drone plugin that was using this as a base image. Interestingly, the issue did not occur in Drone, but only locally, with drone exec, which is probably why it took us a while to spot it.

The root of the issue is described here, https://github.com/docker-library/docker/issues/308, and it's to do with cgroups.

Without this, you will get a cryptic message when running on a host with cgroups v2:
```
[jdk11-build:L15:6s] ⏳ Pinging docker daemon (1/30)
[jdk11-build:L16:6s] sed: write error
```

After upgrading the dind version to 20.10.16, the error was resolved.