### PR TITLE
Add escaping to ampersand

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -17,7 +17,7 @@ if [[ "${PLUGIN_CMD:-}" == "" ]]; then
 fi
 # If multiple cmd lines have been provided, chain them into something which we can execute with sh
 # Note that Drone provides these lines in comma separated form without escaping, which means commas in commands are known to break
-export PLUGIN_CMD=${PLUGIN_CMD//,/ && }
+export PLUGIN_CMD=${PLUGIN_CMD//,/ \&\& }
 
 # Wrap command scriptlet in an invocation of sh
 export PLUGIN_CMD="sh -c '${PLUGIN_CMD}'"


### PR DESCRIPTION
To resolve problem with multi-command Drone scripts caused by a change in Bash 5.1:
> x. New shell option: patsub_replacement. When enabled, a '&' in the replacement
>  string of the pattern substitution expansion is replaced by the portion of
>  the string that matched the pattern. Backslash will escape the '&' and
>  insert a literal '&'.

https://tiswww.case.edu/php/chet/bash/NEWS